### PR TITLE
fix NPE

### DIFF
--- a/android/src/main/java/im/status/ethereum/keycard/RNStatusKeycardModule.java
+++ b/android/src/main/java/im/status/ethereum/keycard/RNStatusKeycardModule.java
@@ -55,12 +55,20 @@ public class RNStatusKeycardModule extends ReactContextBaseJavaModule implements
 
     @ReactMethod
     public void nfcIsSupported(final Promise promise) {
-        promise.resolve(smartCard.isNfcSupported());
+        if (smartCard != null) {
+            promise.resolve(smartCard.isNfcSupported());
+        } else {
+            promise.resolve(false);
+        }
     }
 
     @ReactMethod
     public void nfcIsEnabled(final Promise promise) {
-        promise.resolve(smartCard.isNfcEnabled());
+        if (smartCard != null) {
+            promise.resolve(smartCard.isNfcEnabled());
+        } else {
+            promise.resolve(false);
+        }
     }
 
     @ReactMethod
@@ -72,10 +80,14 @@ public class RNStatusKeycardModule extends ReactContextBaseJavaModule implements
 
     @ReactMethod
     public void start(final Promise promise) {
-        if (smartCard.start()) {
-            promise.resolve(true);
+        if (smartCard != null) {
+            if (smartCard.start()) {
+                promise.resolve(true);
+            } else {
+                promise.reject("Error", "Not supported on this device");
+            }
         } else {
-            promise.reject("Error", "Not supported on this device");
+            promise.reject("Error", "smartCard is not initialized yet");
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 
 {
   "name": "react-native-status-keycard",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "React Native library to interact with Status Keycard using NFC connection (Android only)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fix issue 2 described here https://github.com/status-im/status-react/pull/6893#issuecomment-451427132
```
01-04 15:17:55.093 29571 29620 E AndroidRuntime: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean im.status.ethereum.keycard.SmartCard.isNfcEnabled()' on a null object reference ...
```

This is a quickfix solution. Proper solution with changed method calls order will be implemented next. 