### PR TITLE
Emit keycardDidInit event

### DIFF
--- a/android/src/main/java/im/status/ethereum/keycard/RNStatusKeycardModule.java
+++ b/android/src/main/java/im/status/ethereum/keycard/RNStatusKeycardModule.java
@@ -41,6 +41,8 @@ public class RNStatusKeycardModule extends ReactContextBaseJavaModule implements
     public void onHostResume() {
         if (this.smartCard == null) {
             this.smartCard = new SmartCard(getCurrentActivity(), reactContext);
+            smartCard.eventEmitter.emit("keyCardDidInit", null);
+            Log.d(TAG, "onHostResume");
         }
     }
 

--- a/android/src/main/java/im/status/ethereum/keycard/SmartCard.java
+++ b/android/src/main/java/im/status/ethereum/keycard/SmartCard.java
@@ -38,9 +38,10 @@ public class SmartCard extends BroadcastReceiver implements CardListener {
     private ReactContext reactContext;
     private NfcAdapter nfcAdapter;
     private CardChannel cardChannel;
-    private EventEmitter eventEmitter;
     private static final String TAG = "SmartCard";
     private Boolean started = false;
+
+    public EventEmitter eventEmitter;
 
     private static final String WALLET_PATH = "m/44'/0'/0'/0/0";
     private static final String WHISPER_PATH = "m/43'/60'/1581'/0'/0";
@@ -53,8 +54,6 @@ public class SmartCard extends BroadcastReceiver implements CardListener {
         this.reactContext = reactContext;
         this.nfcAdapter = NfcAdapter.getDefaultAdapter(activity.getBaseContext());
         this.eventEmitter = new EventEmitter(reactContext);
-        eventEmitter.emit("keyCardDidInit", null);
-        Log.d(TAG, "keyCardDidInit ..");
     }
 
     public String getName() {

--- a/android/src/main/java/im/status/ethereum/keycard/SmartCard.java
+++ b/android/src/main/java/im/status/ethereum/keycard/SmartCard.java
@@ -40,6 +40,7 @@ public class SmartCard extends BroadcastReceiver implements CardListener {
     private CardChannel cardChannel;
     private EventEmitter eventEmitter;
     private static final String TAG = "SmartCard";
+    private Boolean started = false;
 
     private static final String WALLET_PATH = "m/44'/0'/0'/0/0";
     private static final String WHISPER_PATH = "m/43'/60'/1581'/0'/0";
@@ -65,15 +66,22 @@ public class SmartCard extends BroadcastReceiver implements CardListener {
     }
 
     public boolean start() {
-        this.cardManager.start();
-        if (this.nfcAdapter != null) {
-            IntentFilter filter = new IntentFilter(NfcAdapter.ACTION_ADAPTER_STATE_CHANGED);
-            activity.registerReceiver(this, filter);
-            nfcAdapter.enableReaderMode(activity, this.cardManager, NfcAdapter.FLAG_READER_NFC_A | NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK, null);
-            return true;
+        if (!started) {
+
+            this.cardManager.start();
+            started = true;
+
+            if (this.nfcAdapter != null) {
+                IntentFilter filter = new IntentFilter(NfcAdapter.ACTION_ADAPTER_STATE_CHANGED);
+                activity.registerReceiver(this, filter);
+                nfcAdapter.enableReaderMode(activity, this.cardManager, NfcAdapter.FLAG_READER_NFC_A | NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK, null);
+                return true;
+            } else {
+                log("not support in this device");
+                return false;
+            }
         } else {
-            log("not support in this device");
-            return false;
+            return true;
         }
     }
 

--- a/android/src/main/java/im/status/ethereum/keycard/SmartCard.java
+++ b/android/src/main/java/im/status/ethereum/keycard/SmartCard.java
@@ -53,6 +53,7 @@ public class SmartCard extends BroadcastReceiver implements CardListener {
         this.nfcAdapter = NfcAdapter.getDefaultAdapter(activity.getBaseContext());
         this.eventEmitter = new EventEmitter(reactContext);
         eventEmitter.emit("keyCardDidInit", null);
+        Log.d(TAG, "keyCardDidInit ..");
     }
 
     public String getName() {

--- a/android/src/main/java/im/status/ethereum/keycard/SmartCard.java
+++ b/android/src/main/java/im/status/ethereum/keycard/SmartCard.java
@@ -52,6 +52,7 @@ public class SmartCard extends BroadcastReceiver implements CardListener {
         this.reactContext = reactContext;
         this.nfcAdapter = NfcAdapter.getDefaultAdapter(activity.getBaseContext());
         this.eventEmitter = new EventEmitter(reactContext);
+        eventEmitter.emit("keyCardDidInit", null);
     }
 
     public String getName() {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 
 {
   "name": "react-native-status-keycard",
-  "version": "2.0.2",
+  "version": "2.1.2",
   "description": "React Native library to interact with Status Keycard using NFC connection (Android only)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
related to https://github.com/status-im/react-native-status-keycard/pull/5

Emit `keycardDidInit` event to allow RN app know that smartCard object has been initialized and it can call `SmartCard` methods like `nfcIsEnabled()` and others.