### PR TITLE
Return master key address and public key

### DIFF
--- a/android/src/main/java/im/status/ethereum/keycard/SmartCard.java
+++ b/android/src/main/java/im/status/ethereum/keycard/SmartCard.java
@@ -48,6 +48,7 @@ public class SmartCard extends BroadcastReceiver implements CardListener {
     private static final String TAG = "SmartCard";
     private Boolean started = false;
 
+    private static final String MASTER_PATH = "m";
     private static final String ROOT_PATH = "m/44'/60'/0'/0";
     private static final String WALLET_PATH = "m/44'/60'/0'/0/0";
     private static final String WHISPER_PATH = "m/43'/60'/1581'/0'/0";
@@ -310,6 +311,9 @@ public class SmartCard extends BroadcastReceiver implements CardListener {
         cmdSet.verifyPIN(pin).checkOK();
         Log.i(TAG, "pin verified");
 
+        byte[] tlvMaster = cmdSet.exportKey(MASTER_PATH, false, true).checkOK().getData();
+        BIP32KeyPair masterPair = BIP32KeyPair.fromTLV(tlvMaster);
+
         byte[] tlvRoot = cmdSet.exportKey(ROOT_PATH, true, true).checkOK().getData();
         BIP32KeyPair keyPair = BIP32KeyPair.fromTLV(tlvRoot);
 
@@ -325,8 +329,10 @@ public class SmartCard extends BroadcastReceiver implements CardListener {
         ApplicationInfo info = new ApplicationInfo(cmdSet.select().checkOK().getData());
 
         WritableMap data = Arguments.createMap();
-        data.putString("address", Hex.toHexString(keyPair.toEthereumAddress()));
-        data.putString("public-key", Hex.toHexString(keyPair.getPublicKey()));
+        data.putString("address", Hex.toHexString(masterPair.toEthereumAddress()));
+        data.putString("public-key", Hex.toHexString(masterPair.getPublicKey()));
+        data.putString("wallet-root-address", Hex.toHexString(keyPair.toEthereumAddress()));
+        data.putString("wallet-root-public-key", Hex.toHexString(keyPair.getPublicKey()));
         data.putString("wallet-address", Hex.toHexString(walletKeyPair.toEthereumAddress()));
         data.putString("wallet-public-key", Hex.toHexString(walletKeyPair.getPublicKey()));
         data.putString("whisper-address", Hex.toHexString(whisperKeyPair.toEthereumAddress()));
@@ -385,8 +391,10 @@ public class SmartCard extends BroadcastReceiver implements CardListener {
         ApplicationInfo info = new ApplicationInfo(cmdSet.select().checkOK().getData());
 
         WritableMap data = Arguments.createMap();
-        data.putString("address", Hex.toHexString(rootKeyPair.toEthereumAddress()));
-        data.putString("public-key", Hex.toHexString(rootKeyPair.getPublicKey()));
+        data.putString("address", Hex.toHexString(keyPair.toEthereumAddress()));
+        data.putString("public-key", Hex.toHexString(keyPair.getPublicKey()));
+        data.putString("wallet-root-address", Hex.toHexString(rootKeyPair.toEthereumAddress()));
+        data.putString("wallet-root-public-key", Hex.toHexString(rootKeyPair.getPublicKey()));
         data.putString("wallet-address", Hex.toHexString(walletKeyPair.toEthereumAddress()));
         data.putString("wallet-public-key", Hex.toHexString(walletKeyPair.getPublicKey()));
         data.putString("whisper-address", Hex.toHexString(whisperKeyPair.toEthereumAddress()));

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -124,8 +124,10 @@ Keycard.generateAndLoadKey(mnemonic, pairing, pin).then(data => console.log(data
 
 `data` object returned:
 ```javascript
-{"address": "b19a57f4d3241e6a123ea332241d6f03790075b4",
-"public-key": "0427cc3998d0e0b8d56b64fad4d1f025914b8cb72558810c74dd34454fcd6907f6f7429a0726dceec9b93c9060103ff8b2e7daa1cb9a4dd62b7ae1ba2232709555",
+{"address": "a89a57f4d3241e6a123ea332241d6f03790075b4",
+"public-key": "04cccc3998d0e0b8d56b64fad4d1f025914b8cb72558810c74dd34454fcd6907f6f7429a0726dceec9b93c9060103ff8b2e7daa1cb9a4dd62b7ae1ba2232709555",
+"wallet-root-address": "b19a57f4d3241e6a123ea332241d6f03790075b4",
+"wallet-root-public-key": "0427cc3998d0e0b8d56b64fad4d1f025914b8cb72558810c74dd34454fcd6907f6f7429a0726dceec9b93c9060103ff8b2e7daa1cb9a4dd62b7ae1ba2232709555",
 "wallet-address": "9726cbc67d170307dd80af6416ebe844e7b8eb1c",
 "wallet-public-key": "04065670509d295cb8330e02a688eafe83dbbb317486062482725ba1036dba396d635e91afd9a9e7087c0dfeaccf30d2004d092ed250d62b5c75f8bb4c9326d409",
 "whisper-address": "438e576b638bff08b2872dd708cf0240811d79af",
@@ -136,9 +138,13 @@ Keycard.generateAndLoadKey(mnemonic, pairing, pin).then(data => console.log(data
 "key-uid":"a88d46499e5690c6ad637e243e83cf51be3e2c67e48324b2b2def3e6a0492576"}
 ```
 
-`address` is an address of root key `m/44'/60'/0'/0`
+`address` is an address of master key `m`
 
-`public-key` is public key of root key `m/44'/60'/0'/0`
+`public-key` is a public key of master key `m`
+
+`wallet-root-address` is an address of root key `m/44'/60'/0'/0`
+
+`wallet-root-public-key` is public key of root key `m/44'/60'/0'/0`
 
 `wallet-address` is ethereum address of key with derivation path `m/44'/60'/0'/0/0`
 
@@ -158,8 +164,10 @@ Keycard.getKeys(pairing, pin).then(data => console.log(data));
 
 `data` object contains:
 ```javascript
-{"address": "b19a57f4d3241e6a123ea332241d6f03790075b4",
-"public-key": "0427cc3998d0e0b8d56b64fad4d1f025914b8cb72558810c74dd34454fcd6907f6f7429a0726dceec9b93c9060103ff8b2e7daa1cb9a4dd62b7ae1ba2232709555",
+{"address": "a89a57f4d3241e6a123ea332241d6f03790075b4",
+"public-key": "04cccc3998d0e0b8d56b64fad4d1f025914b8cb72558810c74dd34454fcd6907f6f7429a0726dceec9b93c9060103ff8b2e7daa1cb9a4dd62b7ae1ba2232709555",
+"wallet-root-address": "b19a57f4d3241e6a123ea332241d6f03790075b4",
+"wallet-root-public-key": "0427cc3998d0e0b8d56b64fad4d1f025914b8cb72558810c74dd34454fcd6907f6f7429a0726dceec9b93c9060103ff8b2e7daa1cb9a4dd62b7ae1ba2232709555",
 "wallet-address": "9726cbc67d170307dd80af6416ebe844e7b8eb1c",
 "wallet-public-key": "04065670509d295cb8330e02a688eafe83dbbb317486062482725ba1036dba396d635e91afd9a9e7087c0dfeaccf30d2004d092ed250d62b5c75f8bb4c9326d409",
 "whisper-address": "438e576b638bff08b2872dd708cf0240811d79af",


### PR DESCRIPTION
Before this commit `Keycard.generateAndLoadKey` and
`Keyacrd.getKeys` methods returned wallet root key address and public
key in "address" and "public-key" fields correspondingly. This caused
discrepancy in the way how keys were used for on-device and keycard
accounts in Status app. For on-device accounts master key address
was used as account's deterministic id, when keycard accounts used
wallet root key address for this purpose.