### PR TITLE
avoid NVM writes (to improve login speed with Keycard)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,5 +41,5 @@ dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation 'org.bouncycastle:bcprov-jdk15on:1.60'
     implementation 'org.apache.commons:commons-lang3:3.9'
-    implementation 'com.github.status-im.status-keycard-java:android:2.2.1'
+    implementation 'com.github.status-im.status-keycard-java:android:3.0.1'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,6 +23,11 @@ android {
         versionCode 1
         versionName "1.0"
     }
+
+    lintOptions {
+        abortOnError false
+    }
+
 }
 
 repositories {

--- a/android/src/main/java/im/status/ethereum/keycard/RNStatusKeycardModule.java
+++ b/android/src/main/java/im/status/ethereum/keycard/RNStatusKeycardModule.java
@@ -233,6 +233,20 @@ public class RNStatusKeycardModule extends ReactContextBaseJavaModule implements
     }
 
     @ReactMethod
+    public void signWithPath(final String pairing, final String pin, final String path, final String hash, final Promise promise) {
+        new Thread(new Runnable() {
+            public void run() {
+                try {
+                    promise.resolve(smartCard.signWithPath(pairing, pin, path, hash));
+                } catch (IOException | APDUException e) {
+                    Log.d(TAG, e.getMessage());
+                    promise.reject(e);
+                }
+            }
+        }).start();
+    }
+
+    @ReactMethod
     public void signPinless(final String hash, final Promise promise) {
         new Thread(new Runnable() {
             public void run() {

--- a/android/src/main/java/im/status/ethereum/keycard/SmartCard.java
+++ b/android/src/main/java/im/status/ethereum/keycard/SmartCard.java
@@ -49,8 +49,6 @@ public class SmartCard extends BroadcastReceiver implements CardListener {
     private static final String TAG = "SmartCard";
     private Boolean started = false;
 
-    private static final String MASTER_PATH = "m";
-    private static final String ROOT_PATH = "m/44'/60'/0'/0";
     private static final String WALLET_PATH = "m/44'/60'/0'/0/0";
     private static final String WHISPER_PATH = "m/43'/60'/1581'/0'/0";
     private static final String ENCRYPTION_PATH = "m/43'/60'/1581'/1'/0";
@@ -314,33 +312,12 @@ public class SmartCard extends BroadcastReceiver implements CardListener {
         cmdSet.verifyPIN(pin).checkOK();
         Log.i(TAG, "pin verified");
 
-        byte[] tlvMaster = cmdSet.exportKey(MASTER_PATH, false, true).checkOK().getData();
-        BIP32KeyPair masterPair = BIP32KeyPair.fromTLV(tlvMaster);
-
-        byte[] tlvRoot = cmdSet.exportKey(ROOT_PATH, false, true).checkOK().getData();
-        BIP32KeyPair keyPair = BIP32KeyPair.fromTLV(tlvRoot);
-
-        byte[] tlv = cmdSet.exportKey(WALLET_PATH, false, true).checkOK().getData();
-        BIP32KeyPair walletKeyPair = BIP32KeyPair.fromTLV(tlv);
-
-        byte[] tlv2 = cmdSet.exportKey(WHISPER_PATH, false, false).checkOK().getData();
-        BIP32KeyPair whisperKeyPair = BIP32KeyPair.fromTLV(tlv2);
-
-        byte[] tlv3 = cmdSet.exportKey(ENCRYPTION_PATH, false, false).checkOK().getData();
-        BIP32KeyPair encryptionKeyPair = BIP32KeyPair.fromTLV(tlv3);
+        byte[] tlv = cmdSet.exportKey(ENCRYPTION_PATH, false, false).checkOK().getData();
+        BIP32KeyPair encryptionKeyPair = BIP32KeyPair.fromTLV(tlv);
 
         ApplicationInfo info = new ApplicationInfo(cmdSet.select().checkOK().getData());
 
         WritableMap data = Arguments.createMap();
-        data.putString("address", Hex.toHexString(masterPair.toEthereumAddress()));
-        data.putString("public-key", Hex.toHexString(masterPair.getPublicKey()));
-        data.putString("wallet-root-address", Hex.toHexString(keyPair.toEthereumAddress()));
-        data.putString("wallet-root-public-key", Hex.toHexString(keyPair.getPublicKey()));
-        data.putString("wallet-address", Hex.toHexString(walletKeyPair.toEthereumAddress()));
-        data.putString("wallet-public-key", Hex.toHexString(walletKeyPair.getPublicKey()));
-        data.putString("whisper-address", Hex.toHexString(whisperKeyPair.toEthereumAddress()));
-        data.putString("whisper-public-key", Hex.toHexString(whisperKeyPair.getPublicKey()));
-        data.putString("whisper-private-key", Hex.toHexString(whisperKeyPair.getPrivateKey()));
         data.putString("encryption-public-key", Hex.toHexString(encryptionKeyPair.getPublicKey()));
         data.putString("instance-uid", Hex.toHexString(info.getInstanceUID()));
         data.putString("key-uid", Hex.toHexString(info.getKeyUID()));
@@ -367,10 +344,6 @@ public class SmartCard extends BroadcastReceiver implements CardListener {
         cmdSet.loadKey(keyPair).checkOK();
         log("keypair loaded to card");
 
-        byte[] tlvMaster = cmdSet.exportKey(ROOT_PATH, false, true).checkOK().getData();
-        Log.i(TAG, "Derived " + ROOT_PATH);
-        BIP32KeyPair rootKeyPair = BIP32KeyPair.fromTLV(tlvMaster);
-
         byte[] tlv = cmdSet.exportKey(WALLET_PATH, false, true).checkOK().getData();
         Log.i(TAG, "Derived " + WALLET_PATH);
         BIP32KeyPair walletKeyPair = BIP32KeyPair.fromTLV(tlv);
@@ -386,10 +359,6 @@ public class SmartCard extends BroadcastReceiver implements CardListener {
         ApplicationInfo info = new ApplicationInfo(cmdSet.select().checkOK().getData());
 
         WritableMap data = Arguments.createMap();
-        data.putString("address", Hex.toHexString(keyPair.toEthereumAddress()));
-        data.putString("public-key", Hex.toHexString(keyPair.getPublicKey()));
-        data.putString("wallet-root-address", Hex.toHexString(rootKeyPair.toEthereumAddress()));
-        data.putString("wallet-root-public-key", Hex.toHexString(rootKeyPair.getPublicKey()));
         data.putString("wallet-address", Hex.toHexString(walletKeyPair.toEthereumAddress()));
         data.putString("wallet-public-key", Hex.toHexString(walletKeyPair.getPublicKey()));
         data.putString("whisper-address", Hex.toHexString(whisperKeyPair.toEthereumAddress()));


### PR DESCRIPTION
* avoid changing the current key when exporting
* introduce signWithPath which can be used instead of deriveKey + sign to avoid persisting the derived key

I didn't remove the exiting deriveKey + sign, so this can be merged without breaking compatibility. There will still be improvements during LOAD KEY and login