### PR TITLE
upgrade to SDK 3.0.2, handle IO errors separately from APDU errors

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,7 +44,7 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'org.bouncycastle:bcprov-jdk15on:1.60'
+    implementation 'org.bouncycastle:bcprov-jdk15on:1.65'
     implementation 'org.apache.commons:commons-lang3:3.9'
-    implementation 'com.github.status-im.status-keycard-java:android:3.0.1'
+    implementation 'com.github.status-im.status-keycard-java:android:3.0.2'
 }

--- a/android/src/main/java/im/status/ethereum/keycard/SmartCard.java
+++ b/android/src/main/java/im/status/ethereum/keycard/SmartCard.java
@@ -233,14 +233,18 @@ public class SmartCard extends BroadcastReceiver implements CardListener {
             Boolean isPaired = false;
 
             if (pairingBase64.length() > 0) {
-                try {
-                    Pairing pairing = new Pairing(pairingBase64);
-                    cmdSet.setPairing(pairing);
+                Pairing pairing = new Pairing(pairingBase64);
+                cmdSet.setPairing(pairing);
 
+                try {
                     cmdSet.autoOpenSecureChannel();
                     Log.i(TAG, "secure channel opened");
                     isPaired = true;
+                } catch(APDUException e) {
+                    Log.i(TAG, "autoOpenSecureChannel failed: " + e.getMessage());
+                }
 
+                if (isPaired) {
                     ApplicationStatus status = new ApplicationStatus(cmdSet.getStatus(KeycardCommandSet.GET_STATUS_P1_APPLICATION).checkOK().getData());
 
                     Log.i(TAG, "PIN retry counter: " + status.getPINRetryCount());
@@ -248,8 +252,6 @@ public class SmartCard extends BroadcastReceiver implements CardListener {
 
                     cardInfo.putInt("pin-retry-counter", status.getPINRetryCount());
                     cardInfo.putInt("puk-retry-counter", status.getPUKRetryCount());
-                } catch (IOException | IllegalArgumentException e) {
-                    Log.i(TAG, "autoOpenSecureChannel failed: " + e.getMessage());
                 }
             }
 


### PR DESCRIPTION
addresses #29 and #25 