### PR TITLE
Faster login times

### DIFF
--- a/android/src/main/java/im/status/ethereum/keycard/RNStatusKeycardModule.java
+++ b/android/src/main/java/im/status/ethereum/keycard/RNStatusKeycardModule.java
@@ -218,13 +218,26 @@ public class RNStatusKeycardModule extends ReactContextBaseJavaModule implements
         }).start();
     }
 
-
     @ReactMethod
     public void getKeys(final String pairing, final String pin, final Promise promise) {
         new Thread(new Runnable() {
             public void run() {
                 try {
                     promise.resolve(smartCard.getKeys(pairing, pin));
+                } catch (IOException | APDUException e) {
+                    Log.d(TAG, e.getMessage());
+                    promise.reject(e);
+                }
+            }
+        }).start();
+    }
+
+    @ReactMethod
+    public void importKeys(final String pairing, final String pin, final Promise promise) {
+        new Thread(new Runnable() {
+            public void run() {
+                try {
+                    promise.resolve(smartCard.importKeys(pairing, pin));
                 } catch (IOException | APDUException e) {
                     Log.d(TAG, e.getMessage());
                     promise.reject(e);
@@ -446,5 +459,5 @@ public class RNStatusKeycardModule extends ReactContextBaseJavaModule implements
     @ReactMethod
     public void setNFCMessage(String message, final Promise promise) {
         promise.resolve(true);
-    }    
+    }
 }

--- a/ios/SmartCard.swift
+++ b/ios/SmartCard.swift
@@ -57,7 +57,7 @@ class SmartCard {
       let rootKeyPair = try exportKey(cmdSet: cmdSet, path: .rootPath, makeCurrent: false, publicOnly: true)
       let whisperKeyPair = try exportKey(cmdSet: cmdSet, path: .whisperPath, makeCurrent: false, publicOnly: false)
       let encryptionKeyPair = try exportKey(cmdSet: cmdSet, path: .encryptionPath, makeCurrent: false, publicOnly: false)
-      let walletKeyPair = try exportKey(cmdSet: cmdSet, path: .walletPath, makeCurrent: true, publicOnly: true)
+      let walletKeyPair = try exportKey(cmdSet: cmdSet, path: .walletPath, makeCurrent: false, publicOnly: true)
 
       let info = try ApplicationInfo(cmdSet.select().checkOK().data)
 
@@ -163,7 +163,7 @@ class SmartCard {
       let masterPair = try exportKey(cmdSet: cmdSet, path: .masterPath, makeCurrent: false, publicOnly: true)
       let rootKeyPair = try exportKey(cmdSet: cmdSet, path: .rootPath, makeCurrent: false, publicOnly: true)
       let whisperKeyPair = try exportKey(cmdSet: cmdSet, path: .whisperPath, makeCurrent: false, publicOnly: false)
-      let walletKeyPair = try exportKey(cmdSet: cmdSet, path: .walletPath, makeCurrent: true, publicOnly: true)
+      let walletKeyPair = try exportKey(cmdSet: cmdSet, path: .walletPath, makeCurrent: false, publicOnly: true)
 
       let info = cmdSet.info!
 

--- a/ios/SmartCard.swift
+++ b/ios/SmartCard.swift
@@ -156,7 +156,7 @@ class SmartCard {
       resolve(bytesToHex(key))
     }
 
-    func getKeys(channel: CardChannel, pairingBase64: String, pin: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) throws -> Void {
+    func importKeys(channel: CardChannel, pairingBase64: String, pin: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) throws -> Void {
       let cmdSet = try authenticatedCommandSet(channel: channel, pairingBase64: pairingBase64, pin: pin)
 
       let encryptionKeyPair = try exportKey(cmdSet: cmdSet, path: .encryptionPath, makeCurrent: false, publicOnly: false)
@@ -165,7 +165,7 @@ class SmartCard {
       let whisperKeyPair = try exportKey(cmdSet: cmdSet, path: .whisperPath, makeCurrent: false, publicOnly: false)
       let walletKeyPair = try exportKey(cmdSet: cmdSet, path: .walletPath, makeCurrent: true, publicOnly: true)
 
-      let info = try ApplicationInfo(cmdSet.select().checkOK().data)
+      let info = cmdSet.info!
 
       resolve([
         "address": bytesToHex(masterPair.toEthereumAddress()),
@@ -174,6 +174,24 @@ class SmartCard {
         "wallet-root-public-key": bytesToHex(rootKeyPair.publicKey),
         "wallet-address": bytesToHex(walletKeyPair.toEthereumAddress()),
         "wallet-public-key": bytesToHex(walletKeyPair.publicKey),
+        "whisper-address": bytesToHex(whisperKeyPair.toEthereumAddress()),
+        "whisper-public-key": bytesToHex(whisperKeyPair.publicKey),
+        "whisper-private-key": bytesToHex(whisperKeyPair.privateKey!),
+        "encryption-public-key": bytesToHex(encryptionKeyPair.publicKey),
+        "instance-uid": bytesToHex(info.instanceUID),
+        "key-uid": bytesToHex(info.keyUID)
+      ])
+    }
+
+    func getKeys(channel: CardChannel, pairingBase64: String, pin: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) throws -> Void {
+      let cmdSet = try authenticatedCommandSet(channel: channel, pairingBase64: pairingBase64, pin: pin)
+
+      let whisperKeyPair = try exportKey(cmdSet: cmdSet, path: .whisperPath, makeCurrent: false, publicOnly: false)
+      let encryptionKeyPair = try exportKey(cmdSet: cmdSet, path: .encryptionPath, makeCurrent: false, publicOnly: false)
+
+      let info = cmdSet.info!
+
+      resolve([
         "whisper-address": bytesToHex(whisperKeyPair.toEthereumAddress()),
         "whisper-public-key": bytesToHex(whisperKeyPair.publicKey),
         "whisper-private-key": bytesToHex(whisperKeyPair.privateKey!),

--- a/ios/StatusKeycard.m
+++ b/ios/StatusKeycard.m
@@ -15,6 +15,7 @@ RCT_EXTERN_METHOD(getApplicationInfo:(NSString *)pairingBase64 resolve:(RCTPromi
 RCT_EXTERN_METHOD(deriveKey:(NSString *)path pairing: (NSString *)pairing pin:(NSString *)pin resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(exportKey:(NSString *)pairing pin:(NSString *)pin resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(exportKeyWithPath:(NSString *)pairing pin:(NSString *)pin path:(NSString *)path resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(importKeys:(NSString *)pairing pin:(NSString *)pin resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(getKeys:(NSString *)pairing pin:(NSString *)pin resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(sign:(NSString *)pairing pin:(NSString *)pin hash:(NSString *)hash resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(signWithPath:(NSString *)pairing pin:(NSString *)pin path:(NSString *)path hash:(NSString *)hash resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)

--- a/ios/StatusKeycard.swift
+++ b/ios/StatusKeycard.swift
@@ -79,6 +79,11 @@ class StatusKeycard: RCTEventEmitter {
     }
 
     @objc
+    func importKeys(_ pairing: String, pin: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
+      keycardInvokation(reject) { [unowned self] channel in try self.smartCard.importKeys(channel: channel, pairingBase64: pairing, pin: pin, resolve: resolve, reject: reject) }
+    }
+
+    @objc
     func getKeys(_ pairing: String, pin: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
       keycardInvokation(reject) { [unowned self] channel in try self.smartCard.getKeys(channel: channel, pairingBase64: pairing, pin: pin, resolve: resolve, reject: reject) }
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-status-keycard",
   "homepage": "https://keycard.status.im/",
-  "version": "2.5.30",
+  "version": "2.5.31",
   "description": "React Native library to interact with Status Keycard using NFC connection (Android only)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
By separating the import process from the login process we can avoid deriving a lot of keys on login.