### PR TITLE
Restore compatibility with applet version < 3.0

### DIFF
--- a/android/src/main/java/im/status/ethereum/keycard/SmartCard.java
+++ b/android/src/main/java/im/status/ethereum/keycard/SmartCard.java
@@ -781,6 +781,10 @@ public class SmartCard extends BroadcastReceiver implements CardListener {
     }
 
     private String getCardNameOrDefault(KeycardCommandSet cmdSet) throws IOException, APDUException {
+        if (cmdSet.getApplicationInfo().getAppVersion() < 0x0300) {
+            return "";
+        }
+
         byte[] data = cmdSet.getData(KeycardCommandSet.STORE_DATA_P1_PUBLIC).checkOK().getData();
 
         try {

--- a/ios/SmartCard.swift
+++ b/ios/SmartCard.swift
@@ -459,6 +459,10 @@ class SmartCard {
     }
     
     func cardNameOrDefault(cmdSet: KeycardCommandSet) throws -> String {
+      if cmdSet.info!.appVersion < 0x0300 {
+        return ""
+      }
+
       let data = try cmdSet.getData(type: Keycard.StoreDataP1.publicData.rawValue).checkOK().data
       
       if data.count > 0 {


### PR DESCRIPTION
applet previous to version 3.0 missed the GET DATA command. Return empty data on these cards instead of throwing exception.